### PR TITLE
Upgrade RuboCop and Supported Ruby version

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 AllCops:
+  TargetRubyVersion: 2.2
   Excludes:
-    - Rakefile
-    - vendor/**
+    - vendor/**/*
     - bin/**
 
 Documentation:
@@ -12,7 +12,23 @@ Encoding:
   # no need to always specify encoding
   Enabled: false
 
-LineLength:
-  # just one more character please
-  Max: 80
+Metrics/BlockLength:
+  Exclude:
+    - grape-markdown.gemspec
+    - spec/**/*
 
+Naming/FileName:
+  Exclude:
+    - lib/grape-markdown.rb
+
+Performance/StringReplacement:
+  Enabled: false
+
+Style/FrozenStringLiteralComment:
+  Enabled: false
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    default: ()
+    "%i": ()
+    "%w": ()

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,11 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.1.0
-  - 2.0.0
-  - 1.9.3
+  - 2.2
+  - 2.3
+  - 2.4
+  - 2.5
   - jruby
 addons:
   code_climate:
-    repo_token: 
+    repo_token:

--- a/Gemfile
+++ b/Gemfile
@@ -2,17 +2,3 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in grape-markdown.gemspec
 gemspec
-
-gem 'grape'
-
-group :development, :test do
-  gem 'coveralls', '~> 0.7'
-  gem 'rspec', '~> 2.14'
-  gem 'bundler', '~> 1.5'
-  gem 'rake', '~> 10.0'
-  gem 'rubocop', '~> 0.18'
-  gem 'pry', '~> 0.9'
-  gem 'guard', '~> 2.4'
-  gem 'guard-rspec', '~> 4.2'
-  gem 'guard-bundler', '~> 2.0'
-end

--- a/Guardfile
+++ b/Guardfile
@@ -1,9 +1,9 @@
 # More info at https://github.com/guard/guard#readme
 
-guard 'rspec', :version => 2 do
+guard 'rspec', version: 2 do
   watch(%r{^spec/.+_spec\.rb$})
   watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
-  watch('spec/spec_helper.rb')  { "spec/" }
+  watch('spec/spec_helper.rb')  { 'spec/' }
 end
 
 guard 'bundler' do

--- a/Rakefile
+++ b/Rakefile
@@ -11,9 +11,9 @@ end
 
 require 'rainbow/ext/string' unless String.respond_to?(:color)
 require 'rubocop/rake_task'
-Rubocop::RakeTask.new(:rubocop)
+RuboCop::RakeTask.new(:rubocop)
 
-task default: [:rubocop, :spec]
+task default: %i(rubocop spec)
 
 task :console do
   require 'pry'

--- a/grape-markdown.gemspec
+++ b/grape-markdown.gemspec
@@ -1,5 +1,6 @@
 # coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'grape-markdown/version'
 
@@ -8,10 +9,16 @@ Gem::Specification.new do |spec|
   spec.version       = GrapeMarkdown::VERSION
   spec.authors       = ['John Allen']
   spec.email         = ['john@threedogconsulting.com']
-  spec.summary       = %q{Allows for generating a Markdown document from you Grape API}
-  spec.description   = %q{Auto generates Markdown from the docuementation that is created by your Grape API}
   spec.homepage      = 'https://github.com/connexio-labs/grape-markdown'
   spec.license       = 'MIT'
+
+  spec.summary = <<-SUMMARY
+    Allows for generating a Markdown document from you Grape API
+  SUMMARY
+
+  spec.description = <<-DESCRIPTION
+    Auto generates Markdown from the docuementation that is created by your Grape API}
+  DESCRIPTION
 
   spec.files         = `git ls-files -z`.split("\x0")
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
@@ -20,13 +27,13 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'grape', '>= 1.1.0'
 
-  spec.add_development_dependency 'coveralls', '~> 0.7'
-  spec.add_development_dependency 'rspec', '~> 2.14'
   spec.add_development_dependency 'bundler', '~> 1.5'
-  spec.add_development_dependency 'rake', '~> 10.0'
-  spec.add_development_dependency 'rubocop', '~> 0.18'
-  spec.add_development_dependency 'pry', '~> 0.9'
+  spec.add_development_dependency 'coveralls', '~> 0.7'
   spec.add_development_dependency 'guard', '~> 2.4'
-  spec.add_development_dependency 'guard-rspec', '~> 4.2'
   spec.add_development_dependency 'guard-bundler', '~> 2.0'
+  spec.add_development_dependency 'guard-rspec', '~> 4.2'
+  spec.add_development_dependency 'pry', '~> 0.9'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 2.14'
+  spec.add_development_dependency 'rubocop', '~> 0.60.0'
 end

--- a/lib/grape-markdown/configuration.rb
+++ b/lib/grape-markdown/configuration.rb
@@ -1,14 +1,14 @@
 module GrapeMarkdown
   class Configuration
-    SETTINGS = [
-      :name,
-      :description,
-      :request_headers,
-      :response_headers,
-      :example_id_type,
-      :resource_exclusion,
-      :include_root
-    ]
+    SETTINGS = %i(
+      name
+      description
+      request_headers
+      response_headers
+      example_id_type
+      resource_exclusion
+      include_root
+    ).freeze
 
     class << self
       attr_accessor(*SETTINGS)
@@ -34,14 +34,14 @@ module GrapeMarkdown
       end
 
       def supported_id_types
-        [:integer, :uuid, :bson]
+        %i(integer uuid bson)
       end
 
       def example_id_type=(value)
-        fail UnsupportedIDType unless supported_id_types.include?(value)
+        raise UnsupportedIDType unless supported_id_types.include?(value)
 
         if value.to_sym == :bson && !Object.const_defined?('BSON')
-          fail BSONNotDefinied
+          raise BSONNotDefinied
         end
 
         @example_id_type = value

--- a/lib/grape-markdown/document.rb
+++ b/lib/grape-markdown/document.rb
@@ -18,7 +18,7 @@ module GrapeMarkdown
     end
 
     def write
-      fail 'Not yet supported'
+      raise 'Not yet supported'
     end
 
     def routes
@@ -29,7 +29,7 @@ module GrapeMarkdown
 
     def resources
       @resources ||= begin
-        grouped_routes = routes.group_by(&:route_name).reject do |name, routes|
+        grouped_routes = routes.group_by(&:route_name).reject do |name, _routes|
           resource_exclusion.include?(name.parameterize.underscore.to_sym)
         end
 

--- a/lib/grape-markdown/parameter.rb
+++ b/lib/grape-markdown/parameter.rb
@@ -28,17 +28,15 @@ module GrapeMarkdown
       JSON.parse(options.to_json, object_class: OpenStruct)
     end
 
-    def default_options(options)
+    def default_options(_options)
       model = name.include?('_id') ? name.gsub('_id', '') : route.route_name
 
       {
-        required:       true,
-        requirement:    'required',
-        type:           'uuid',
-        desc:           "the `id` of the `#{model}`",
-        documentation:  {
-          example:      GrapeMarkdown::Configuration.generate_id
-        }
+        required: true,
+        requirement: 'required',
+        type: 'uuid',
+        desc: "the `id` of the `#{model}`",
+        documentation: { example: GrapeMarkdown::Configuration.generate_id }
       }
     end
   end

--- a/lib/grape-markdown/resource.rb
+++ b/lib/grape-markdown/resource.rb
@@ -20,7 +20,7 @@ module GrapeMarkdown
     end
 
     def paths
-      @paths ||= routes.group_by(&:route_path_without_format).map do |n, routes|
+      @paths ||= routes.group_by(&:route_path_without_format).map do |_, routes|
         Resource.new(name, routes)
       end
     end

--- a/lib/grape-markdown/route.rb
+++ b/lib/grape-markdown/route.rb
@@ -2,11 +2,13 @@ module GrapeMarkdown
   class Route < SimpleDelegator
     # would like to rely on SimpleDelegator but Grape::Route uses
     # method_missing for these methods :'(
-    delegate :namespace,
-             :path,
-             :request_method,
-             :route_description,
-             to: '__getobj__'
+    delegate(
+      :namespace,
+      :path,
+      :request_method,
+      :route_description,
+      to: '__getobj__'
+    )
 
     def root_resource
       namespace.split('/').reject(&:empty?).first

--- a/lib/grape-markdown/version.rb
+++ b/lib/grape-markdown/version.rb
@@ -1,3 +1,3 @@
 module GrapeMarkdown
-  VERSION = '0.0.6'
+  VERSION = '0.0.6'.freeze
 end

--- a/spec/grape-markdown/configuration_spec.rb
+++ b/spec/grape-markdown/configuration_spec.rb
@@ -42,7 +42,7 @@ describe GrapeMarkdown::Configuration do
   end
 
   context 'headers' do
-    [:request_headers, :response_headers].each do |type|
+    %i(request_headers response_headers).each do |type|
       context type do
         it 'is an array' do
           expect(subject.send(type)).to be_a(Array)

--- a/spec/grape-markdown/resource_spec.rb
+++ b/spec/grape-markdown/resource_spec.rb
@@ -15,7 +15,9 @@ describe GrapeMarkdown::Resource do
     it 'response generation is delegated to a generator' do
       expect(subject.sample_generator).to receive(:response)
 
-      subject.sample_response(GrapeMarkdown::Route.new(Grape::Router::Route.new('GET', '/')))
+      subject.sample_response(
+        GrapeMarkdown::Route.new(Grape::Router::Route.new('GET', '/'))
+      )
     end
   end
 end

--- a/spec/support/config_context.rb
+++ b/spec/support/config_context.rb
@@ -1,7 +1,7 @@
 shared_context 'configuration' do
   let(:name)               { 'some api v1' }
   let(:description)        { 'some blueprint description' }
-  let(:resource_exclusion) { [:admin, :swagger_docs] }
+  let(:resource_exclusion) { %i(admin swagger_docs) }
 
   let(:request_headers) do
     [{ 'Accept-Charset' => 'utf-8' }]

--- a/spec/support/sample_api.rb
+++ b/spec/support/sample_api.rb
@@ -27,7 +27,7 @@ class SampleApi < Grape::API
       optional :name, type: String, desc: 'the widgets name'
       optional :description, type: String, desc: 'the widgets name'
     end
-    put  ':id' do
+    put ':id' do
     end
   end
 


### PR DESCRIPTION
A [recent PR](https://github.com/technekes/grape-markdown/pull/3#issuecomment-438264310) illustrated some outdated versions of RuboCop and Ruby support.